### PR TITLE
Adding version bumper and resetting versions

### DIFF
--- a/config/csharp-netcore.json
+++ b/config/csharp-netcore.json
@@ -1,13 +1,14 @@
 {
-    "packageName": "Oanda.V20",
+    "packageName": "GeriRemenyi.Oanda.V20",
+    "packageVersion": "0.0.1",
     "packageTags": [
         "OANDA",
         "REST",
         "V20",
         ".NET",
         ".NET Core",
-        "client"
+        "client",
+        "geriremenyi"
     ],
-    "targetFramework": "netcoreapp3.1",
-    "packageVersion": "1.0.0"
+    "targetFramework": "netcoreapp3.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oanda-openapi",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "OANDA REST API V20 openapi definition",
   "repository": "git@github.com:geriremenyi/oanda-openapi.git",
   "author": "Gergely Reményi <geri@geriremenyi.com>",
@@ -12,7 +12,7 @@
     "bundle": "swagger-cli bundle src/openapi.yaml -o out/definition/openapi.yaml -t yaml -r",
     "generate:csharp-netcore": "openapi-generator generate -i out/definition/openapi.yaml -g csharp-netcore -o out/code/csharp-netcore -c config/csharp-netcore.json"
   },
-  "dependencies": {
+  "devDependencies": {
     "@apidevtools/swagger-cli": "^4.0.4",
     "@openapitools/openapi-generator-cli": "^1.0.15-4.3.1"
   }

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Parameters to named parameters
+version_type=$1
+
+# Parameter checks
+if [ "$version_type" = "" ] 
+then
+    echo "[WARNING] Version type was not given. Setting version type to 'patch'"
+    version_type="patch"
+else 
+    if [ "$version_type" != "patch" ] && [ "$version_type" != "minor" ] && [ "$version_type" != "major" ]
+    then
+        echo "[ERROR] The first parameter is the version type which should be either 'patch', 'minor' or 'major'."
+        exit 1
+    fi
+fi
+
+# Bumping version in package.json
+new_version=$(npm version "$version_type" --no-git-tag-version | sed "s/[^0-9\.]*//g")
+echo "[INFO] Node package version was updated to $new_version"
+
+# Bumping version in all config files
+for config_file in ./config/*.json; do
+    sed -i "s/\"packageVersion\":.*\,/\"packageVersion\": \"$new_version\"\,/g" "$config_file"
+    echo "[INFO] Config file '$config_file' was updated to $new_version"
+done


### PR DESCRIPTION
# Issue

## Type
- [x] :sparkles: Feature 
- [ ] :bug: Bug

# Technical description
Current version is fixed to `1.0.0` and can be updated only manually only.

# Solution description
Resetting the version to `0.0.1` as the starting version (as the package is not yet reaching a stable major version) and adding a bash script to be able to bump the version for the node environment and the corresponding codegen config files.

# Tests
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests