### PR TITLE
Fixing some .NET core codegen issues

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -50,6 +50,8 @@ jobs:
           path: out/definition
       - name: Generate .NET core code
         run: npm run generate:csharp-netcore
+      - name: Workaround for .NET core generation issue
+        run: sudo ./scripts/remove_basevalidate.sh
       - name: Clone oanda-dotnet-client
         working-directory: ../
         run: sudo ./oanda-openapi/scripts/git_clone.sh github.com geriremenyi oanda-dotnet-client master "${{ secrets.BOT_USER_ID }}" "${{ secrets.BOT_USER_ACCESS_TOKEN }}"

--- a/config/csharp-netcore.json
+++ b/config/csharp-netcore.json
@@ -1,14 +1,12 @@
 {
     "packageName": "GeriRemenyi.Oanda.V20",
     "packageVersion": "0.0.1",
-    "packageTags": [
-        "OANDA",
-        "REST",
-        "V20",
-        ".NET",
-        ".NET Core",
-        "client",
-        "geriremenyi"
-    ],
-    "targetFramework": "netcoreapp3.1"
+    "targetFramework": "netcoreapp3.1",
+    "packageAuthors": "geriremenyi",
+    "packageCompany": "geriremenyi.com",
+    "packageTitle": "OANDA REST V20 .NET core client",
+    "packageDescription": "A generated client library for OANDA REST V20 API",
+    "gitUserId": "geriremenyi",
+    "gitRepoId": "oanda-dotnet-client",
+    "packageTags": "OANDA;REST V20;.NET Core client;geriremenyi"
 }

--- a/scripts/remove_basevalidate.sh
+++ b/scripts/remove_basevalidate.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# This is needed because of the bug 
+# https://github.com/OpenAPITools/openapi-generator/issues/5416 in the openapi-generator
+
+# Removing 'foreach(var x in BaseValidate(validationContext)) yield return x;' lines
+for model_file in ./out/code/csharp-netcore/src/GeriRemenyi.OANDA.V20/Model/*.cs; do
+    sed -i "s/foreach(var x in BaseValidate(validationContext)) yield return x;//g" "$model_file"
+done


### PR DESCRIPTION
# Issue

## Type
- [ ] :sparkles: Feature 
- [x] :bug: Bug

## Link 
[[BUG][csharp-netcore] : 'BaseValidate' does not exist in the current context](https://github.com/OpenAPITools/openapi-generator/issues/5416)

# Technical description
There is an issue in the .NET core codegen tool. It adds a BaseValidate method call to the validate method (in model classes) but the BaseValidate method doesn't generated for some models.

# Solution description
A new bash script was introduced (`remove_basevalidate.sh`) to remove those lines from all models where it is present.

# Tests
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests